### PR TITLE
Move external dependencies into package.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,36 +57,6 @@ $ npm install -g bower
 
   If you get an error, please check the next section "Post-install"
 
-### Post-install (post-dependecies)
-
-  Get bufferput package from Github repository:
-
-    $ git clone git@github.com:gasteve/node-bufferput.git
-
-  Create symbolic link of node-bufferput in your insight folder:
-
-    $ cd <your_path_to>/insight/node_modules
-    $ ln -s <path_to>/node-bufferput bufferput
-
-    Get bitcore from github repository:
-  
-  Get bitcore from github repository:
-    
-    $ git clone https://github.com/bitpay/bitcore.git
-    
-    $ cd bitcore
-    
-    $ npm install
-
-  Then create a symbolic link from this to your insight repository. We need to
-  use bitcore from github, not with npm for now:
-
-    $ cd insight/node_modules
-
-    $ rm -R bitcore
-
-    $ ln -s <path-to-your-clone-repositoy>/bitcore
-
 ## Syncing old blockchain data
 
   Run sync from insight repository (to save old blocks and transactions in MongoDB):

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "mongoose": "~3.8.3",
     "lodash": "~2.4.1",
     "bower": "~1.2.8",
-    "bitcore": "*",
     "buffertools": "*",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.11",
@@ -75,7 +74,9 @@
     "socket.io": "~0.9.16",
     "moment": "~2.5.0",
     "sinon": "~1.7.3",
-    "chai": "~1.8.1"
+    "chai": "~1.8.1",
+    "bitcore": "git://github.com/bitpay/bitcore.git",
+    "bufferput": "git://github.com/bitpay/node-bufferput.git"
   },
   "devDependencies": {
     "grunt-contrib-watch": "latest",


### PR DESCRIPTION
This pull request should allow `npm install` to automatically set up the dependencies that have not yet been published to npm, making for an easier install.
