### PR TITLE
Rounding issue: transactions on front page sometimes have too many decimal places

### DIFF
--- a/app/controllers/socket.js
+++ b/app/controllers/socket.js
@@ -3,6 +3,7 @@
 // server-side socket behaviour
 // io is a variable already taken in express
 var ios = null;
+var util = require('bitcore/util/util');
 
 module.exports.init = function(app, io_ext) {
   ios = io_ext;
@@ -25,10 +26,10 @@ module.exports.broadcastTx = function(tx) {
       // Outputs
       var valueOut = 0;
       t.vout.forEach( function(o) {
-        valueOut += o.value * 100000000;
+        valueOut += o.value * util.COIN;
       });
 
-      t.valueOut = valueOut / 100000000;
+      t.valueOut = parseInt(valueOut) / util.COIN;
     }
     ios.sockets.in('inv').emit('tx', t);
   }

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -24,7 +24,7 @@
             </td>
             <td><span class="ellipsis">{{humanSince(b.time)}}</span></td>
             <td class="text-right">{{b.txlength}}</td>
-            <td class="text-right">{{b.size}}</td>
+            <td class="text-right">{{b.size}} bytes</td>
           </tr>
           </tbody>
         </table>


### PR DESCRIPTION
One transaction visible on the front page was for 18.760522849999997 BTC ... 15 decimal places. Viewing the transaction page itself does not reveal any problems - it's only when the transaction is on the front page.

The tx in question is: ecfcc2209212c5f597ff4a908c901a5469978adefe5ed3a77b2355ab37d6dae7
