### PR TITLE
Fixed copy value for scriptPubKey on tx list

### DIFF
--- a/public/views/transaction/tx.html
+++ b/public/views/transaction/tx.html
@@ -161,7 +161,7 @@
               <div class="small">
                 <p><strong>scriptPubKey</strong></p>
                 <span class="col-md-11 text-muted ellipsis">{{vout.scriptPubKey.asm}}</span>
-                <span class="btn-copy col-md-1" clip-copy="tx.txid"></span>
+                <span class="btn-copy col-md-1" clip-copy="vout.scriptPubKey.asm"></span>
               </div>
           </div>
         </div>


### PR DESCRIPTION
It was copying the transaction ID, not the scriptPubKey. This issue #439 
