### PR TITLE
Add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /address
+Disallow: /api
+Disallow: /transaction


### PR DESCRIPTION
Adds a "robots.txt" [1] file to the public folder to discourage unnecessary bot traffic. The disallowed routes in this file are (inspired by #544):
- /address
- /api
- /transaction

[1] http://www.robotstxt.org/robotstxt.html
