### PR TITLE
Remove template from meta description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
 	<meta name="fragment" content="!">
 	<title data-ng-bind="$root.title + $root.titleDetail + ' | Insight'">Insight</title>
 	<meta name="keywords" content="bitcoins, transactions, blocks, address, block chain, best block, mining difficulty, hash serialized">
-	<meta name="description" content="Bitcoin Insight. View detailed information on all bitcoin transactions and block. {{ $root.title + $root.titleDetail }}">
+	<meta name="description" content="Bitcoin Insight. View detailed information on all bitcoin transactions and block.">
 	<link rel="shortcut icon" href="img/icons/favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,400italic">
 	<link rel="stylesheet" href="css/main.min.css">


### PR DESCRIPTION
The template is not being rendered and that makes the template to be shown raw in the description.
