### PR TITLE
Address page for insight ui

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -33,3 +33,9 @@ Ctrl+D out of mongo
 
 rm -rf ${bcoin-prefix-in-config.js}/chain.ldb
 ```
+
+### Contributing
+
+1. Fork
+2. Branch
+3. Send a PR

--- a/server/README.md
+++ b/server/README.md
@@ -12,23 +12,15 @@ npm install
 npm start
 ```
 
-http://localhost:3000
+A Full Bcoin node will start in console.
 
-A Full Bcoin node will start in console. As blocks come in they will be stored in Mongo. You can refresh the page to see the blocks sync. When the socket portion is complete you can watch live but it may be too fast (watch console).
+http://localhost:3000
 
 ### Configuration
 
 A configuration object exists in /config/index.js
 
 Bcoin accepts a config object per Bcoin docs. Same for Mongo/Mongoose
-
-### Misc Gotchas / Needs Docs & clarity
-
-To reset/start over you need to drop both mongo and delete the bcoin datadir.
-
-Bcoin offers a few database types. The most ideal for our purpose is the in memory database. Unfortunately, Bcoin will not record blockchain sync checkpoints in this mode. Every restart of the client would result in Bcoin sync'ing from the Genesis block. Long term, we should consider sending them a friendly PR that includes some sort of flat file last height persistence.
-
-Alternatively, I've explored putting mongo into Bcoin. The db interface seems simple enough. Bcoin mostly get/puts but it is surprisingly complicated under the hood. So Bcoin creates its own leveldb for now.
 
 ### Resetting Application State
 ```
@@ -39,32 +31,5 @@ db.transactions.drop()
 
 Ctrl+D out of mongo
 
-rm -rf ${bcoin-prefix-in-config}/chain.ldb
+rm -rf ${bcoin-prefix-in-config.js}/chain.ldb
 ```
-
-### Nginx
-
-The API is configured to run on port 3000 by default. Use the standard Nginx reverse proxy on ports 80/443 to flip http to https and handle ssl certs.
-
-### Priorities
-https://docs.google.com/a/bit-pay.com/spreadsheets/d/1hDlf16F6zAxBrOC3ZdnvfRrSB9bvdgohf1GxAIM9_Fk/edit?usp=sharing
-
-# ToDo but required for a release
-* Finish API Endpoints (3-ish remain);
-* Mongo Models : Bcoin primitives. A Bcoin block primitive does not represent all of bitcore's data.
-1. scriptpubkey asm
-2. peer's best block height is learned on peer connect but not retained by the app. Block height is the current sync height
-3. Multiple Outputs were overlooked in the mongo model
-* Post-sync listeners are not wired up yet (sockets).
-* Parameters for some routes are missing. Spreadsheet is not 100% complete. Need a test run / qa round.
-
-# ToDo but not Required for a release
-* Reorg testing - Bcoin will handle this but we need to account for this in our mongo indexes.
-* JSDoc & Unit tests
-* Rate Limiting
-* Helmet for security
-* Caching
-* Sanitize user input - mongo and api params. Just make a quick middleware.
-* Change Mongo subdocuments into .populate Object Id relationships. This will reduce size & increase performance
-* Make the current api the 'legacy' api and setup a real api with uniform verbage/params
-* Remove hh:mm:ss from log file names and append to same file for the same day

--- a/server/lib/api/address.js
+++ b/server/lib/api/address.js
@@ -7,9 +7,11 @@ const MAX_BLOCKS = 200;
 function getBlock(params, options, limit, cb) {
   const defaultOptions = { _id: 0 };
 
-  Object.assign(defaultOptions, options);
+  if (!Number.isInteger(limit)) {
+    limit = MAX_BLOCKS;
+  }
 
-  console.log
+  Object.assign(defaultOptions, options);
 
   Block.find(
     params,
@@ -21,11 +23,55 @@ function getBlock(params, options, limit, cb) {
 
 module.exports = function AddressAPI(router) {
   router.get('/addr/:addr', (req, res) => {
+    res.json({
+      addrStr:                 req.params.addr,
+      balance:                 0,
+      balanceSat:              0,
+      totalReceived:           0,
+      totalReceivedSat:        0,
+      totalSent:               0,
+      totalSentSat:            0,
+      unconfirmedBalance:      0,
+      unconfirmedBalanceSat:   0,
+      unconfirmedTxApperances: 0,
+      txApperances:            5,
+    });
+  });
+
+  router.get('/addr/:addr/utxo', (req, res) => {
+    res.send('1');
+  });
+
+  router.get('/addr/:addr/balance', (req, res) => {
+    res.send('2');
+  });
+
+  router.get('/addr/:addr/totalReceived', (req, res) => {
+    res.send('3');
+  });
+
+  router.get('/addr/:addr/totalSent', (req, res) => {
+    res.send('4');
+  });
+
+  router.get('/addr/:addr/unconfirmedBalance', (req, res) => {
+    res.send('5');
+  });
+
+  router.get('/addrs/:addrs/utxo', (req, res) => {
+    res.send('6');
+  });
+
+  router.post('/addrs/utxo', (req, res) => {
+    res.send('7');
+  });
+
+  router.get('/addrs/:addrs/txs', (req, res) => {
     getBlock(
       {
         $or:
         [
-          { 'txs.outputs.address':     req.params.addr },
+          { 'txs.outputs.address': req.params.addr },
           { 'txs.inputs.prevout.hash': req.params.addr },
         ],
       },
@@ -70,38 +116,6 @@ module.exports = function AddressAPI(router) {
           res.send();
         }
       });
-  });
-
-  router.get('/addr/:addr/utxo', (req, res) => {
-    res.send("1");
-  });
-
-  router.get('/addr/:addr/balance', (req, res) => {
-    res.send("2");
-  });
-
-  router.get('/addr/:addr/totalReceived', (req, res) => {
-    res.send("3");
-  });
-
-  router.get('/addr/:addr/totalSent', (req, res) => {
-    res.send("4");
-  });
-
-  router.get('/addr/:addr/unconfirmedBalance', (req, res) => {
-    res.send("5");
-  });
-
-  router.get('/addrs/:addrs/utxo', (req, res) => {
-    res.send("6");
-  });
-
-  router.post('/addrs/utxo', (req, res) => {
-    res.send("7");
-  });
-
-  router.get('/addrs/:addrs/txs', (req, res) => {
-    res.send("8");
   });
 
   router.post('/addrs/txs', (req, res) => {

--- a/server/lib/api/address.js
+++ b/server/lib/api/address.js
@@ -1,4 +1,9 @@
-module.exports = function addressrouter(router) {
+const Block = require('../../models/block.js');
+const logger = require('../logger');
+
+const MAX_BLOCKS = 200;
+
+module.exports = function AddressAPI(router) {
   router.get('/addr/:addr', (req, res) => {
     res.send(req.params.addr);
   });

--- a/server/lib/api/address.js
+++ b/server/lib/api/address.js
@@ -3,41 +3,105 @@ const logger = require('../logger');
 
 const MAX_BLOCKS = 200;
 
+// Shoe horned in. Not dry, also in blocks. Make db api later
+function getBlock(params, options, limit, cb) {
+  const defaultOptions = { _id: 0 };
+
+  Object.assign(defaultOptions, options);
+
+  console.log
+
+  Block.find(
+    params,
+    defaultOptions,
+    cb)
+    .sort({ height: -1 })
+    .limit(limit);
+}
+
 module.exports = function AddressAPI(router) {
   router.get('/addr/:addr', (req, res) => {
-    res.send(req.params.addr);
+    getBlock(
+      {
+        $or:
+        [
+          { 'txs.outputs.address':     req.params.addr },
+          { 'txs.inputs.prevout.hash': req.params.addr },
+        ],
+      },
+      { rawBlock: 0 },
+      MAX_BLOCKS,
+      (err, block) => {
+        if (err) {
+          res.status(501).send();
+          logger.log('err', err);
+        }
+
+        if (block[0]) {
+          const b = block[0];
+          res.json({
+            pagesTotal: 1,
+            txs: b.txs.map(tx => ({
+              txid: tx.hash,
+              version: tx.version,
+              locktime: tx.locktime,
+              vin: tx.inputs.map(input => ({
+                coinbase: input.script,
+                sequence: input.sequence,
+                n: 0,
+                addr: input.address,
+              })),
+              vout: tx.outputs.map(output => ({
+                value: output.value / 1e8,
+                n: 0,
+                scriptPubKey: {
+                  hex: '',
+                  asm: '',
+                  addresses: [output.address],
+                  type: output.type,
+                },
+                spentTxid: '',
+                spentIndex: 0,
+                spentHeight: 0,
+              })),
+            })),
+          });
+        } else {
+          res.send();
+        }
+      });
   });
 
   router.get('/addr/:addr/utxo', (req, res) => {
-    res.send(req.params.addr);
+    res.send("1");
   });
 
   router.get('/addr/:addr/balance', (req, res) => {
-    res.send(req.params.addr);
+    res.send("2");
   });
 
   router.get('/addr/:addr/totalReceived', (req, res) => {
-    res.send(req.params.addr);
+    res.send("3");
   });
 
   router.get('/addr/:addr/totalSent', (req, res) => {
-    res.send(req.params.addr);
+    res.send("4");
   });
 
   router.get('/addr/:addr/unconfirmedBalance', (req, res) => {
-    res.send(req.params.addr);
+    res.send("5");
   });
 
   router.get('/addrs/:addrs/utxo', (req, res) => {
-    res.send(req.params.addrs);
+    res.send("6");
   });
 
   router.post('/addrs/utxo', (req, res) => {
-    res.send('post stub');
+    res.send("7");
   });
 
   router.get('/addrs/:addrs/txs', (req, res) => {
-    res.send(req.params.addrs);
+    res.send("8");
   });
 
   router.post('/addrs/txs', (req, res) => {

--- a/server/lib/api/cors.js
+++ b/server/lib/api/cors.js
@@ -1,0 +1,37 @@
+module.exports = function (req, res, next) {
+  let allowed = {
+
+    origins: [
+      '*',
+    ],
+
+    methods: [
+      'HEAD',
+      'GET',
+      'POST',
+      'PUT',
+      'DELETE',
+      'OPTIONS',
+    ],
+
+    headers: [
+      'Content-Type',
+      'Authorization',
+      'Content-Length',
+      'X-Requested-With',
+      'Cache-Control',
+      'X-Accept-Version',
+      'x-signature',
+      'x-pubkey',
+      'x-identity',
+      'cf-connecting-ip',
+    ],
+
+  };
+
+  res.header('Access-Control-Allow-Origin', allowed.origins.join());
+  res.header('Access-Control-Allow-Methods', allowed.methods.join());
+  res.header('Access-Control-Allow-Headers', allowed.headers.join());
+
+  next();
+};

--- a/server/lib/api/index.js
+++ b/server/lib/api/index.js
@@ -3,9 +3,9 @@ const config  = require('../../config');
 
 const app = express();
 const api = express.Router();
-const CORS = require('./CORS');
+const cors = require('./cors');
 
-app.use(CORS);
+app.use(cors);
 
 // Serve insight ui front end from root dir public folder
 app.use('/', express.static('./public'));

--- a/server/lib/api/index.js
+++ b/server/lib/api/index.js
@@ -3,6 +3,9 @@ const config  = require('../../config');
 
 const app = express();
 const api = express.Router();
+const CORS = require('./CORS');
+
+app.use(CORS);
 
 // Serve insight ui front end from root dir public folder
 app.use('/', express.static('./public'));

--- a/server/lib/api/socket.js
+++ b/server/lib/api/socket.js
@@ -1,23 +1,15 @@
 module.exports = function addressrouter(io) {
   io.on('connection', (socket) => {
     socket.on('subscribe', (data) => {
-      console.log('subscribe message');
-      console.log(data);
     });
 
     socket.on('message', (data) => {
-      console.log('unsubscribe message');
-      console.log(data);
     });
 
     socket.on('unsubscribe', (data) => {
-      console.log('unsubscribe message');
-      console.log(data);
     });
 
     socket.on('disconnect', (data) => {
-      console.log('unsubscribe message');
-      console.log(data);
     });
   });
 };

--- a/server/lib/api/transaction.js
+++ b/server/lib/api/transaction.js
@@ -111,6 +111,7 @@ module.exports = function transactionAPI(router) {
                   coinbase: input.script,
                   sequence: input.sequence,
                   n: 0,
+                  addr: input.address,
                 })),
                 vout: tx.outputs.map(output => ({
                   value: output.value / 1e8,

--- a/server/lib/api/transaction.js
+++ b/server/lib/api/transaction.js
@@ -6,8 +6,12 @@ const MAX_TXS = 20;
 const MAX_BLOCKS = 1;
 
 // Shoe horned in. Not dry, also in blocks. Make db api later
-function getBlock(params, options, cb) {
+function getBlock(params, options, limit, cb) {
   const defaultOptions = { _id: 0 };
+
+  if (!Number.isInteger(limit)) {
+    limit = MAX_BLOCKS;
+  }
 
   Object.assign(defaultOptions, options);
 
@@ -16,7 +20,7 @@ function getBlock(params, options, cb) {
     defaultOptions,
     cb)
     .sort({ height: -1 })
-    .limit(MAX_BLOCKS);
+    .limit(limit);
 }
 
 
@@ -85,15 +89,11 @@ module.exports = function transactionAPI(router) {
   });
 
   router.get('/txs', (req, res) => {
-/*
-    const txsBy = req.query.blocks ||
-                  req.query.address;
-*/
-
     if (req.query.block) {
       getBlock(
         { hash: req.query.block },
         { rawBlock: 0 },
+        MAX_BLOCKS,
         (err, block) => {
           if (err) {
             res.status(501).send();
@@ -133,7 +133,54 @@ module.exports = function transactionAPI(router) {
           }
         });
     } else if (req.query.address) {
+      getBlock(
+        { $or:
+          [
+            { 'txs.outputs.address':     req.query.address },
+            { 'txs.inputs.prevout.hash': req.query.address },
+          ],
+        },
+        { rawBlock: 0 },
+        MAX_BLOCKS,
+        (err, block) => {
+          if (err) {
+            res.status(501).send();
+            logger.log('err', err);
+          }
 
+          if (block[0]) {
+            const b = block[0];
+            res.json({
+              pagesTotal: 1,
+              txs: b.txs.map(tx => ({
+                txid: tx.hash,
+                version: tx.version,
+                locktime: tx.locktime,
+                vin: tx.inputs.map(input => ({
+                  coinbase: input.script,
+                  sequence: input.sequence,
+                  n: 0,
+                  addr: input.address,
+                })),
+                vout: tx.outputs.map(output => ({
+                  value: output.value / 1e8,
+                  n: 0,
+                  scriptPubKey: {
+                    hex: '',
+                    asm: '',
+                    addresses: [output.address],
+                    type: output.type,
+                  },
+                  spentTxid: '',
+                  spentIndex: 0,
+                  spentHeight: 0,
+                })),
+              })),
+            });
+          } else {
+            res.send();
+          }
+        });
     } else {
       getTransactions(
         {},

--- a/server/lib/api/transaction.js
+++ b/server/lib/api/transaction.js
@@ -146,9 +146,7 @@ module.exports = function transactionAPI(router) {
           if (err) {
             res.status(501).send();
             logger.log('err', err);
-          }
-
-          if (block[0]) {
+          } else if (block[0]) {
             const b = block[0];
             res.json({
               pagesTotal: 1,

--- a/server/lib/node/index.js
+++ b/server/lib/node/index.js
@@ -39,7 +39,7 @@ function start() {
   });
 
   node.pool.on('peer', (peer) => {
-    // console.log(peer);
+
   });
 
   node.on('error', (err) => {
@@ -48,7 +48,7 @@ function start() {
   });
 
   node.mempool.on('tx', (tx) => {
-    console.log(tx)
+
   });
 }
 

--- a/server/lib/parser/address.js
+++ b/server/lib/parser/address.js
@@ -7,30 +7,13 @@ const logger      = require('../logger');
 
 function parse(entry, txs) {
   txs.forEach((tx) => {
-    //const txJSON = tx.toJSON();
 
     tx.outputs.forEach((output) => {
       const outputJSON = output.toJSON();
-
-      /*
-      return new OutputModel({
-        address: outputJSON.address,
-        script:  outputJSON.script,
-        value:   outputJSON.value,
-      });*/
     });
 
     tx.inputs.forEach((input) => {
       const inputJSON = input.toJSON();
-
-/*        return new InputModel({
-          prevout:  inputJSON.prevout,
-          script:   inputJSON.script,
-          witness:  inputJSON.witness,
-          sequence: inputJSON.sequence,
-          address:  inputJSON.address,
-        });
-      })*/
     });
   });
 }

--- a/server/lib/parser/address.js
+++ b/server/lib/parser/address.js
@@ -11,7 +11,7 @@ function parse(entry, txs) {
 
     tx.outputs.forEach((output) => {
       const outputJSON = output.toJSON();
-      //console.log(outputJSON);
+
       /*
       return new OutputModel({
         address: outputJSON.address,
@@ -22,7 +22,7 @@ function parse(entry, txs) {
 
     tx.inputs.forEach((input) => {
       const inputJSON = input.toJSON();
-      //console.log(inputJSON);
+
 /*        return new InputModel({
           prevout:  inputJSON.prevout,
           script:   inputJSON.script,

--- a/server/lib/parser/transaction.js
+++ b/server/lib/parser/transaction.js
@@ -16,18 +16,19 @@ function parse(entry, txs) {
     counter++;
 
     if (counter % socketThrottle === 0) {
+
       io.sockets.emit('tx', {
         txid: txJSON.hash,
-        valueOut: tx.outputs.reduce((a, b) => {
-          a = a.toJSON();
-          b = b.toJSON();
+        valueOut: tx.outputs.reduce((sum, tx) => {
+          tx = tx.toJSON();
 
-          const valA = (a.value || a.valueOut.value || 0) / 1e8;
-          const valB = (b.value || b.valueOut.value || 0) / 1e8;
+          const valB = (tx.value || tx.valueOut.value || 0) / 1e8;
 
-          return valA + valB;
-        }),
-      }, 0);
+          console.log(valB)
+
+          return sum + valB;
+        }, 0),
+      });
     }
 
     const t = new TxModel({

--- a/server/lib/parser/transaction.js
+++ b/server/lib/parser/transaction.js
@@ -24,8 +24,6 @@ function parse(entry, txs) {
 
           const valB = (tx.value || tx.valueOut.value || 0) / 1e8;
 
-          console.log(valB)
-
           return sum + valB;
         }, 0),
       });


### PR DESCRIPTION
**_DNM before: https://github.com/bitpay/insight/pull/790_**

/addr/:addr
/txs w/ address param   
/addrs/:addrs/txs - shares the same code as address param

ER:
Fire up a node
Click one of the latest blocks
Click on an address

![image](https://user-images.githubusercontent.com/6285466/29201396-f0063ec4-7e2b-11e7-9722-f696d1865926.png)

/addr/:addr data is stubbed. This would be a good starting point for building out db api library.

txs should fill in. No pagination yet.

Pretty soon we should consider building out the db api / interface and thinning out the api. It shouldn't get too bad getting all of insight ui's needs but we should refactor into the db api before doing the remaining routes.

@nitsujlangston @kleetus @bitjson @gabegattis @SonicWizard