### PR TITLE
Quick fix to blocks api to prevent mapping undefined and crashing the…

### DIFF
--- a/server/lib/api/block.js
+++ b/server/lib/api/block.js
@@ -76,18 +76,22 @@ module.exports = function BlockAPI(router) {
           res.status(501).send();
           logger.log('err', err);
         }
-        res.json({
-          blocks: blocks.map(block => ({
-            hash: block.hash,
-            height: block.height,
-            size: block.size,
-            time: block.ts,
-            txlength: block.txs.length,
-            poolInfo: {},
-          })),
-          length: blocks.length,
-          pagination: {},
-        });
+        if (blocks.length > 0) {
+          res.json({
+            blocks: blocks.map(block => ({
+              hash: block.hash,
+              height: block.height,
+              size: block.size,
+              time: block.ts,
+              txlength: block.txs.length,
+              poolInfo: {},
+            })),
+            length: blocks.length,
+            pagination: {},
+          });
+        } else {
+          res.send();
+        }
       });
   });
 

--- a/server/lib/api/block.js
+++ b/server/lib/api/block.js
@@ -76,7 +76,9 @@ module.exports = function BlockAPI(router) {
           res.status(501).send();
           logger.log('err', err);
         }
-        if (blocks.length > 0) {
+        if (!blocks.length) {
+          res.send();
+        } else {
           res.json({
             blocks: blocks.map(block => ({
               hash: block.hash,
@@ -89,8 +91,6 @@ module.exports = function BlockAPI(router) {
             length: blocks.length,
             pagination: {},
           });
-        } else {
-          res.send();
         }
       });
   });


### PR DESCRIPTION
… server.

I was unable to track down root cause but there is a situation where the /blocks endpoint can return undefined. Mapping undefined is unsafe JS so this is a quick shim fix to avoid the crash for now.

@nitsujlangston @bitjson @kleetus @gabegattis @SonicWizard 