### PR TITLE
added proxy to pull data from proper url

### DIFF
--- a/app/ionic.config.json
+++ b/app/ionic.config.json
@@ -4,5 +4,9 @@
   "type": "ionic-angular",
   "integrations": {
     "cordova": {}
-  }
+  },
+  "proxies": [{
+    "path": "/api",
+    "proxyUrl": "http://localhost:3000/api"
+  }]
 }


### PR DESCRIPTION
This includes an ionic proxy config setting to allow the `ionic serve` app to hit a different API url/port.