### PR TITLE
Redirect /tx -> /#/tx

### DIFF
--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -19,7 +19,7 @@ import { BlocksProvider } from '../providers/blocks/blocks';
     BrowserModule,
     HttpModule,
     PagesModule,
-    IonicModule.forRoot(InsightApp, {locationStrategy: 'path'})
+    IonicModule.forRoot(InsightApp)
   ],
   bootstrap: [IonicApp],
   entryComponents: [

--- a/app/src/app/app.module.ts
+++ b/app/src/app/app.module.ts
@@ -19,7 +19,7 @@ import { BlocksProvider } from '../providers/blocks/blocks';
     BrowserModule,
     HttpModule,
     PagesModule,
-    IonicModule.forRoot(InsightApp)
+    IonicModule.forRoot(InsightApp, {locationStrategy: 'path'})
   ],
   bootstrap: [IonicApp],
   entryComponents: [

--- a/bitcore-node/index.js
+++ b/bitcore-node/index.js
@@ -45,13 +45,15 @@ InsightUI.prototype.getRoutePrefix = function() {
 InsightUI.prototype.setupRoutes = function(app, express) {
   var self = this;
   app.use(express.static(__dirname + '/../app/www'));
-  // if not in found, fall back to indexFile (404 is handled client-side)
-  /*
-  app.use(function(req, res) {
-    res.setHeader('Content-Type', 'text/html');
-    res.send(self.indexFile);
+  app.use((req, resp, next) => {
+    const url = req.originalUrl;
+    if (!url.includes("#") && !url.includes(".")) {
+      const redirectTo = `/#${url}`;
+      resp.redirect(redirectTo);
+    } else {
+      next();
+    }
   });
-  */
 };
 
 InsightUI.prototype.filterIndexHTML = function(data) {


### PR DESCRIPTION
The goal of this is to redirect frontend requests, like /tx to /#/tx

This may need exclusion of /api, or perhaps we want an explicit whitelist.